### PR TITLE
Gate `version_get_number` test in `lib.rs` on `vendored` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,12 @@ pub mod types {
     }
 }
 
+#[cfg(not(feature = "vendored"))]
+include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+
 #[test]
-#[cfg(test)]
+#[cfg(all(not(feature = "vendored"), test))]
+//#[cfg(test)]
 fn version_get_number() {
 
     unsafe {


### PR DESCRIPTION
`cargo test` now work regardless of whether the `vendored` feature is enabled.

Worth noting this effectively reverts the previous commit by re-adding the import. Might be worth an interactive rebase to drop that commit if we keep these changes.